### PR TITLE
Alignments iOS - Android - paddings and text-sizes

### DIFF
--- a/ScalaDays/Controllers/SDAboutViewController.swift
+++ b/ScalaDays/Controllers/SDAboutViewController.swift
@@ -62,7 +62,7 @@ class SDAboutViewController: UIViewController, SDErrorPlaceholderViewDelegate, S
     private func setupAppareance() {
         separatorH.constant = 0.25
 
-        descriptionTextView.contentInset = UIEdgeInsets(top: 8, left: 12, bottom: -18, right: 8)
+        descriptionTextView.contentInset = UIEdgeInsets(top: 6, left: 12, bottom: -22, right: 8)
         descriptionTextView.setHTMLAppareance([.foregroundColor: UIColor.appRedColor()],
                                               textColor: .appColor())
     }

--- a/ScalaDays/Controllers/SDAboutViewController.xib
+++ b/ScalaDays/Controllers/SDAboutViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -39,14 +39,14 @@
                             </constraints>
                         </view>
                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="logo_47deg" translatesAutoresizingMaskIntoConstraints="NO" id="dvg-HY-4XP">
-                            <rect key="frame" x="12" y="6.5" width="34" height="34"/>
+                            <rect key="frame" x="16" y="6.5" width="34" height="34"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="34" id="4Wb-a9-9hF"/>
                                 <constraint firstAttribute="width" constant="34" id="lFn-Du-GkY"/>
                             </constraints>
                         </imageView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="The official Scala Days App for iOS handcrafted by 47 Degrees" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="jG5-ky-XNF">
-                            <rect key="frame" x="56" y="16" width="350" height="14.5"/>
+                            <rect key="frame" x="66" y="16" width="340" height="14.5"/>
                             <fontDescription key="fontDescription" name="HelveticaNeue-Light" family="Helvetica Neue" pointSize="12"/>
                             <color key="textColor" red="0.3333333432674408" green="0.3333333432674408" blue="0.3333333432674408" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
@@ -61,9 +61,9 @@
                         <constraint firstAttribute="bottom" secondItem="jG5-ky-XNF" secondAttribute="bottom" constant="16" id="aja-2I-PPN"/>
                         <constraint firstAttribute="trailing" secondItem="7gj-Jz-JgV" secondAttribute="trailing" id="dBf-Wa-bso"/>
                         <constraint firstAttribute="trailing" secondItem="jG5-ky-XNF" secondAttribute="trailing" constant="8" id="hcy-U4-5gG"/>
-                        <constraint firstItem="dvg-HY-4XP" firstAttribute="leading" secondItem="8tL-Xa-Mlu" secondAttribute="leading" constant="12" id="oTN-CD-DYR"/>
+                        <constraint firstItem="dvg-HY-4XP" firstAttribute="leading" secondItem="8tL-Xa-Mlu" secondAttribute="leading" constant="16" id="oTN-CD-DYR"/>
                         <constraint firstItem="7gj-Jz-JgV" firstAttribute="leading" secondItem="8tL-Xa-Mlu" secondAttribute="leading" id="qSs-bQ-CIb"/>
-                        <constraint firstItem="jG5-ky-XNF" firstAttribute="leading" secondItem="dvg-HY-4XP" secondAttribute="trailing" constant="10" id="rBi-bZ-F6n"/>
+                        <constraint firstItem="jG5-ky-XNF" firstAttribute="leading" secondItem="dvg-HY-4XP" secondAttribute="trailing" constant="16" id="rBi-bZ-F6n"/>
                     </constraints>
                     <connections>
                         <outletCollection property="gestureRecognizers" destination="Kot-YP-7dU" appends="YES" id="pS5-gF-r4Z"/>

--- a/ScalaDays/Controllers/SDSlideMenuViewController.swift
+++ b/ScalaDays/Controllers/SDSlideMenuViewController.swift
@@ -108,7 +108,7 @@ class SDSlideMenuViewController: UIViewController, UITableViewDelegate, UITableV
         self.tblMenu.scrollsToTop = false
         self.tblConferences.scrollsToTop = false
         
-        self.titleConference.setCustomFont(UIFont.fontHelveticaNeue(17), colorFont: UIColor.white)
+        self.titleConference.setCustomFont(UIFont.fontHelveticaNeue(16), colorFont: UIColor.white)
         
         let notificationViewController = SDNotificationViewController(analytics: analytics, notificationManager: notificationManager)
         self.notificationNavigationController = UINavigationController(rootViewController: notificationViewController)

--- a/ScalaDays/Controllers/SDSlideMenuViewController.xib
+++ b/ScalaDays/Controllers/SDSlideMenuViewController.xib
@@ -1,8 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="14C109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SDSlideMenuViewController" customModule="ScalaDays" customModuleProvider="target">
@@ -19,28 +21,28 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wmo-tt-doA">
-                    <rect key="frame" x="0.0" y="0.0" width="600" height="150"/>
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="150"/>
                     <subviews>
                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="placeholder_menu" translatesAutoresizingMaskIntoConstraints="NO" id="tpM-kA-yta">
-                            <rect key="frame" x="0.0" y="0.0" width="600" height="150"/>
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="150"/>
                         </imageView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="San Francisco" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JLQ-ZL-etP">
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="San Francisco" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JLQ-ZL-etP">
                             <rect key="frame" x="15" y="112" width="110" height="21"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="A2a-gt-hi5">
-                            <rect key="frame" x="22" y="95" width="558" height="55"/>
+                            <rect key="frame" x="22" y="95" width="372" height="55"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="55" id="mkA-9v-uxq"/>
                             </constraints>
                             <state key="normal" image="menu_header_select_arrow">
-                                <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </state>
                             <connections>
                                 <action selector="selectedConference:" destination="-1" eventType="touchDown" id="FTo-z7-Nl4"/>
@@ -61,32 +63,32 @@
                     </constraints>
                 </view>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" allowsSelectionDuringEditing="YES" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="lxn-hm-0cu">
-                    <rect key="frame" x="0.0" y="149" width="600" height="30"/>
-                    <color key="backgroundColor" red="0.21176470589999999" green="0.27058823529999998" blue="0.31372549020000001" alpha="1" colorSpace="calibratedRGB"/>
+                    <rect key="frame" x="0.0" y="149" width="414" height="30"/>
+                    <color key="backgroundColor" red="0.21176470589999999" green="0.27058823529999998" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="30" id="UCW-so-Pom"/>
                     </constraints>
-                    <color key="sectionIndexBackgroundColor" red="0.21176470589999999" green="0.27058823529999998" blue="0.31372549020000001" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="sectionIndexBackgroundColor" red="0.21176470589999999" green="0.27058823529999998" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <connections>
                         <outlet property="dataSource" destination="-1" id="OEU-Lm-sYd"/>
                         <outlet property="delegate" destination="-1" id="9l6-5A-M57"/>
                     </connections>
                 </tableView>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="A86-Fs-poj">
-                    <rect key="frame" x="0.0" y="149" width="600" height="30"/>
-                    <color key="backgroundColor" red="0.21176470589999999" green="0.27058823529999998" blue="0.31372549020000001" alpha="1" colorSpace="calibratedRGB"/>
+                    <rect key="frame" x="0.0" y="149" width="414" height="30"/>
+                    <color key="backgroundColor" red="0.21176470589999999" green="0.27058823529999998" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="30" id="rHa-mP-oUU"/>
                     </constraints>
-                    <color key="sectionIndexBackgroundColor" red="0.21176470589999999" green="0.27058823529999998" blue="0.31372549020000001" alpha="1" colorSpace="calibratedRGB"/>
-                    <color key="sectionIndexTrackingBackgroundColor" red="0.21176470589999999" green="0.27058823529999998" blue="0.31372549020000001" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="sectionIndexBackgroundColor" red="0.21176470589999999" green="0.27058823529999998" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <color key="sectionIndexTrackingBackgroundColor" red="0.21176470589999999" green="0.27058823529999998" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <connections>
                         <outlet property="dataSource" destination="-1" id="PuC-wJ-KmN"/>
                         <outlet property="delegate" destination="-1" id="1rM-vT-mdL"/>
                     </connections>
                 </tableView>
             </subviews>
-            <color key="backgroundColor" red="0.21176470588235294" green="0.27058823529411763" blue="0.31372549019607843" alpha="1" colorSpace="calibratedRGB"/>
+            <color key="backgroundColor" red="0.21176470588235294" green="0.27058823529411763" blue="0.31372549019607843" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstAttribute="bottom" secondItem="A86-Fs-poj" secondAttribute="bottom" id="4h0-P1-kms"/>
                 <constraint firstItem="lxn-hm-0cu" firstAttribute="top" secondItem="wmo-tt-doA" secondAttribute="bottom" constant="-1" id="62C-aA-XDE"/>
@@ -108,7 +110,7 @@
         </view>
     </objects>
     <resources>
-        <image name="menu_header_select_arrow" width="11" height="11"/>
+        <image name="menu_header_select_arrow" width="10.5" height="10.5"/>
         <image name="placeholder_menu" width="298" height="188"/>
     </resources>
 </document>

--- a/ScalaDays/Controllers/SDSocialViewController.swift
+++ b/ScalaDays/Controllers/SDSocialViewController.swift
@@ -54,6 +54,7 @@ class SDSocialViewController: UIViewController, UITableViewDelegate, UITableView
         
         tblView?.register(UINib(nibName: "SDSocialTableViewCell", bundle: nil), forCellReuseIdentifier: kReuseIdentifier)
         tblView?.addSubview(refreshControl)
+        tblView?.tableFooterView = UIView()
         if isIOS8OrLater() {
             tblView?.estimatedRowHeight = kEstimatedDynamicCellsRowHeightHigh
         }

--- a/ScalaDays/Controllers/SDSponsorViewController.xib
+++ b/ScalaDays/Controllers/SDSponsorViewController.xib
@@ -1,8 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="13E28" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SDSponsorViewController" customModule="ScalaDays" customModuleProvider="target">
@@ -13,25 +15,26 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <tableView hidden="YES" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="cnW-nM-bJg">
-                    <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                     <connections>
                         <outlet property="dataSource" destination="-1" id="qXR-Br-dxo"/>
                         <outlet property="delegate" destination="-1" id="pHH-ic-oi8"/>
                     </connections>
                 </tableView>
             </subviews>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="cnW-nM-bJg" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="Dvo-hG-iuW"/>
                 <constraint firstItem="cnW-nM-bJg" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="Vv7-Pa-ckn"/>
                 <constraint firstAttribute="trailing" secondItem="cnW-nM-bJg" secondAttribute="trailing" id="h8E-G2-j5M"/>
                 <constraint firstAttribute="bottom" secondItem="cnW-nM-bJg" secondAttribute="bottom" id="kIv-Me-xEz"/>
             </constraints>
+            <point key="canvasLocation" x="26" y="52"/>
         </view>
     </objects>
 </document>

--- a/ScalaDays/UI/TableViewCells/SDSocialTableViewCell.xib
+++ b/ScalaDays/UI/TableViewCells/SDSocialTableViewCell.xib
@@ -10,10 +10,10 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="socialViewControllerCell" rowHeight="201" id="6fL-s0-MWD" customClass="SDSocialTableViewCell" customModule="ScalaDays" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="468" height="201"/>
+            <rect key="frame" x="0.0" y="0.0" width="468" height="210"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" placeholderIntrinsicWidth="468" placeholderIntrinsicHeight="200" tableViewCell="6fL-s0-MWD" id="6js-rk-2M5">
-                <rect key="frame" x="0.0" y="0.0" width="468" height="201"/>
+                <rect key="frame" x="0.0" y="0.0" width="468" height="210"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Zd4-Hr-SWq">
@@ -31,7 +31,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" placeholderIntrinsicWidth="385" placeholderIntrinsicHeight="15" text="Username" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="385" translatesAutoresizingMaskIntoConstraints="NO" id="Jln-r8-itq">
-                        <rect key="frame" x="72" y="38" width="376" height="15"/>
+                        <rect key="frame" x="72" y="39" width="376" height="15"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                         <nil key="highlightedColor"/>
@@ -43,7 +43,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" placeholderIntrinsicWidth="390" placeholderIntrinsicHeight="124" text="Content" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="240" translatesAutoresizingMaskIntoConstraints="NO" id="OMf-HF-JG4">
-                        <rect key="frame" x="72" y="61" width="380" height="124"/>
+                        <rect key="frame" x="72" y="62" width="380" height="124"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                         <nil key="highlightedColor"/>
@@ -56,9 +56,9 @@
                     <constraint firstAttribute="trailing" secondItem="GaI-gF-yEE" secondAttribute="trailing" constant="16" id="FyY-9C-JVG"/>
                     <constraint firstItem="OMf-HF-JG4" firstAttribute="top" secondItem="GaI-gF-yEE" secondAttribute="bottom" constant="27" id="Ser-By-Y7p"/>
                     <constraint firstItem="OMf-HF-JG4" firstAttribute="leading" secondItem="Zd4-Hr-SWq" secondAttribute="trailing" constant="16" id="SsR-CF-Wvu"/>
-                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="OMf-HF-JG4" secondAttribute="bottom" constant="8" id="YG2-Mf-b6s"/>
+                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="OMf-HF-JG4" secondAttribute="bottom" constant="16" id="YG2-Mf-b6s"/>
                     <constraint firstItem="LdR-fe-uSb" firstAttribute="leading" secondItem="6js-rk-2M5" secondAttribute="leading" constant="63" id="dlx-J1-P9Q"/>
-                    <constraint firstItem="Jln-r8-itq" firstAttribute="top" secondItem="LdR-fe-uSb" secondAttribute="bottom" constant="3" id="gtL-wm-WRt"/>
+                    <constraint firstItem="Jln-r8-itq" firstAttribute="top" secondItem="LdR-fe-uSb" secondAttribute="bottom" constant="4" id="gtL-wm-WRt"/>
                     <constraint firstItem="Zd4-Hr-SWq" firstAttribute="leading" secondItem="6js-rk-2M5" secondAttribute="leading" constant="16" id="hlI-8F-NSz"/>
                     <constraint firstItem="Zd4-Hr-SWq" firstAttribute="top" secondItem="6js-rk-2M5" secondAttribute="top" constant="16" id="huk-Ye-291"/>
                     <constraint firstItem="OMf-HF-JG4" firstAttribute="top" secondItem="Jln-r8-itq" secondAttribute="bottom" constant="8" id="mLc-ZQ-G9z"/>

--- a/ScalaDays/UI/TableViewCells/SDSocialTableViewCell.xib
+++ b/ScalaDays/UI/TableViewCells/SDSocialTableViewCell.xib
@@ -1,8 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="13E28" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -11,36 +13,37 @@
             <rect key="frame" x="0.0" y="0.0" width="468" height="201"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" placeholderIntrinsicWidth="468" placeholderIntrinsicHeight="200" tableViewCell="6fL-s0-MWD" id="6js-rk-2M5">
+                <rect key="frame" x="0.0" y="0.0" width="468" height="201"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Zd4-Hr-SWq">
-                        <rect key="frame" x="15" y="20" width="40" height="40"/>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.0" colorSpace="calibratedRGB"/>
+                        <rect key="frame" x="16" y="16" width="40" height="40"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="40" id="Ief-et-1d5"/>
                             <constraint firstAttribute="width" constant="40" id="pxP-Gs-bf3"/>
                         </constraints>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" placeholderIntrinsicWidth="75" placeholderIntrinsicHeight="19" text="Full name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="75" translatesAutoresizingMaskIntoConstraints="NO" id="LdR-fe-uSb">
-                        <rect key="frame" x="63" y="23" width="75" height="19"/>
+                        <rect key="frame" x="72" y="16" width="75" height="19"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" placeholderIntrinsicWidth="385" placeholderIntrinsicHeight="15" text="Username" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="385" translatesAutoresizingMaskIntoConstraints="NO" id="Jln-r8-itq">
-                        <rect key="frame" x="63" y="45" width="385" height="15"/>
+                        <rect key="frame" x="72" y="38" width="376" height="15"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" placeholderIntrinsicWidth="72" placeholderIntrinsicHeight="15" text="Time ago" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="72" translatesAutoresizingMaskIntoConstraints="NO" id="GaI-gF-yEE">
-                        <rect key="frame" x="383" y="26" width="72" height="15"/>
+                        <rect key="frame" x="380" y="16" width="72" height="15"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" placeholderIntrinsicWidth="390" placeholderIntrinsicHeight="124" text="Content" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="240" translatesAutoresizingMaskIntoConstraints="NO" id="OMf-HF-JG4">
-                        <rect key="frame" x="63" y="68" width="390" height="124"/>
+                        <rect key="frame" x="72" y="61" width="380" height="124"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                         <nil key="highlightedColor"/>
@@ -48,20 +51,20 @@
                 </subviews>
                 <constraints>
                     <constraint firstAttribute="trailing" secondItem="Jln-r8-itq" secondAttribute="trailing" constant="20" id="3E8-9N-5v0"/>
-                    <constraint firstItem="GaI-gF-yEE" firstAttribute="top" secondItem="6js-rk-2M5" secondAttribute="top" constant="26" id="4Bv-z6-Hws"/>
-                    <constraint firstItem="Jln-r8-itq" firstAttribute="leading" secondItem="Zd4-Hr-SWq" secondAttribute="trailing" constant="8" id="DB5-dy-rA4"/>
-                    <constraint firstAttribute="trailing" secondItem="GaI-gF-yEE" secondAttribute="trailing" constant="13" id="FyY-9C-JVG"/>
+                    <constraint firstItem="Jln-r8-itq" firstAttribute="leading" secondItem="Zd4-Hr-SWq" secondAttribute="trailing" constant="16" id="DB5-dy-rA4"/>
+                    <constraint firstItem="LdR-fe-uSb" firstAttribute="top" secondItem="Zd4-Hr-SWq" secondAttribute="top" id="FLj-4Y-R3Z"/>
+                    <constraint firstAttribute="trailing" secondItem="GaI-gF-yEE" secondAttribute="trailing" constant="16" id="FyY-9C-JVG"/>
                     <constraint firstItem="OMf-HF-JG4" firstAttribute="top" secondItem="GaI-gF-yEE" secondAttribute="bottom" constant="27" id="Ser-By-Y7p"/>
-                    <constraint firstItem="OMf-HF-JG4" firstAttribute="leading" secondItem="Zd4-Hr-SWq" secondAttribute="trailing" constant="8" id="SsR-CF-Wvu"/>
-                    <constraint firstItem="LdR-fe-uSb" firstAttribute="top" secondItem="6js-rk-2M5" secondAttribute="top" constant="23" id="VRu-mM-CFq"/>
-                    <constraint firstAttribute="bottom" secondItem="OMf-HF-JG4" secondAttribute="bottom" constant="8" id="YG2-Mf-b6s"/>
+                    <constraint firstItem="OMf-HF-JG4" firstAttribute="leading" secondItem="Zd4-Hr-SWq" secondAttribute="trailing" constant="16" id="SsR-CF-Wvu"/>
+                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="OMf-HF-JG4" secondAttribute="bottom" constant="8" id="YG2-Mf-b6s"/>
                     <constraint firstItem="LdR-fe-uSb" firstAttribute="leading" secondItem="6js-rk-2M5" secondAttribute="leading" constant="63" id="dlx-J1-P9Q"/>
                     <constraint firstItem="Jln-r8-itq" firstAttribute="top" secondItem="LdR-fe-uSb" secondAttribute="bottom" constant="3" id="gtL-wm-WRt"/>
-                    <constraint firstItem="Zd4-Hr-SWq" firstAttribute="leading" secondItem="6js-rk-2M5" secondAttribute="leading" constant="15" id="hlI-8F-NSz"/>
-                    <constraint firstItem="Zd4-Hr-SWq" firstAttribute="top" secondItem="6js-rk-2M5" secondAttribute="top" constant="20" id="huk-Ye-291"/>
+                    <constraint firstItem="Zd4-Hr-SWq" firstAttribute="leading" secondItem="6js-rk-2M5" secondAttribute="leading" constant="16" id="hlI-8F-NSz"/>
+                    <constraint firstItem="Zd4-Hr-SWq" firstAttribute="top" secondItem="6js-rk-2M5" secondAttribute="top" constant="16" id="huk-Ye-291"/>
                     <constraint firstItem="OMf-HF-JG4" firstAttribute="top" secondItem="Jln-r8-itq" secondAttribute="bottom" constant="8" id="mLc-ZQ-G9z"/>
-                    <constraint firstAttribute="trailing" secondItem="OMf-HF-JG4" secondAttribute="trailing" constant="15" id="ndG-WH-bx7"/>
-                    <constraint firstItem="LdR-fe-uSb" firstAttribute="leading" secondItem="Zd4-Hr-SWq" secondAttribute="trailing" constant="8" id="saF-5M-OGE"/>
+                    <constraint firstItem="GaI-gF-yEE" firstAttribute="top" secondItem="Zd4-Hr-SWq" secondAttribute="top" id="mwb-Ez-dII"/>
+                    <constraint firstAttribute="trailing" secondItem="OMf-HF-JG4" secondAttribute="trailing" constant="16" id="ndG-WH-bx7"/>
+                    <constraint firstItem="LdR-fe-uSb" firstAttribute="leading" secondItem="Zd4-Hr-SWq" secondAttribute="trailing" constant="16" id="saF-5M-OGE"/>
                 </constraints>
                 <variation key="default">
                     <mask key="constraints">

--- a/ScalaDays/UI/TableViewCells/SDSpeakersTableViewCell.xib
+++ b/ScalaDays/UI/TableViewCells/SDSpeakersTableViewCell.xib
@@ -10,10 +10,10 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="SpeakersListCell" rowHeight="201" id="xJf-eO-yL5" userLabel="speakersTableViewCell" customClass="SDSpeakersTableViewCell" customModule="ScalaDays" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="468" height="200"/>
+            <rect key="frame" x="0.0" y="0.0" width="468" height="210"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" placeholderIntrinsicWidth="468" placeholderIntrinsicHeight="200" tableViewCell="xJf-eO-yL5" id="3Qk-c8-3ba">
-                <rect key="frame" x="0.0" y="0.0" width="468" height="200"/>
+                <rect key="frame" x="0.0" y="0.0" width="468" height="210"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="cp0-I6-JZO">
@@ -49,7 +49,7 @@
                     <constraint firstItem="6pQ-OD-SEB" firstAttribute="top" secondItem="cp0-I6-JZO" secondAttribute="top" id="4fb-zJ-3ey"/>
                     <constraint firstAttribute="trailing" secondItem="gQE-zL-xxH" secondAttribute="trailing" constant="16" id="89B-8U-mgC"/>
                     <constraint firstItem="ajq-lL-NRj" firstAttribute="top" secondItem="6pQ-OD-SEB" secondAttribute="bottom" constant="4" id="G11-xm-kwB"/>
-                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="gQE-zL-xxH" secondAttribute="bottom" constant="8" id="IaG-CR-IVZ"/>
+                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="gQE-zL-xxH" secondAttribute="bottom" constant="16" id="IaG-CR-IVZ"/>
                     <constraint firstItem="gQE-zL-xxH" firstAttribute="top" secondItem="ajq-lL-NRj" secondAttribute="bottom" constant="8" id="KdO-c0-C08"/>
                     <constraint firstItem="cp0-I6-JZO" firstAttribute="top" secondItem="3Qk-c8-3ba" secondAttribute="top" constant="16" id="NHv-yv-J6D"/>
                     <constraint firstItem="6pQ-OD-SEB" firstAttribute="leading" secondItem="3Qk-c8-3ba" secondAttribute="leading" constant="63" id="TG1-lC-YTa"/>

--- a/ScalaDays/UI/TableViewCells/SDSpeakersTableViewCell.xib
+++ b/ScalaDays/UI/TableViewCells/SDSpeakersTableViewCell.xib
@@ -1,58 +1,60 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="13E28" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="SpeakersListCell" rowHeight="201" id="xJf-eO-yL5" userLabel="speakersTableViewCell" customClass="SDSpeakersTableViewCell" customModule="ScalaDays" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="468" height="201"/>
+            <rect key="frame" x="0.0" y="0.0" width="468" height="200"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" placeholderIntrinsicWidth="468" placeholderIntrinsicHeight="200" tableViewCell="xJf-eO-yL5" id="3Qk-c8-3ba">
+                <rect key="frame" x="0.0" y="0.0" width="468" height="200"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="cp0-I6-JZO">
-                        <rect key="frame" x="15" y="20" width="40" height="40"/>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.0" colorSpace="calibratedRGB"/>
+                        <rect key="frame" x="16" y="16" width="40" height="40"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="40" id="chc-sT-kpo"/>
                             <constraint firstAttribute="height" constant="40" id="xWg-gP-Jfd"/>
                         </constraints>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" placeholderIntrinsicWidth="75" placeholderIntrinsicHeight="19" text="Full name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="75" translatesAutoresizingMaskIntoConstraints="NO" id="6pQ-OD-SEB">
-                        <rect key="frame" x="63" y="23" width="75" height="19"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <rect key="frame" x="72" y="16" width="75" height="19"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" placeholderIntrinsicWidth="385" placeholderIntrinsicHeight="15" text="Username" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="385" translatesAutoresizingMaskIntoConstraints="NO" id="ajq-lL-NRj">
-                        <rect key="frame" x="63" y="45" width="385" height="15"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <rect key="frame" x="72" y="39" width="385" height="15"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" placeholderIntrinsicWidth="390" placeholderIntrinsicHeight="124" text="Content" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="240" translatesAutoresizingMaskIntoConstraints="NO" id="gQE-zL-xxH">
-                        <rect key="frame" x="63" y="68" width="390" height="124"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <rect key="frame" x="72" y="62" width="380" height="124"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="cp0-I6-JZO" firstAttribute="leading" secondItem="3Qk-c8-3ba" secondAttribute="leading" constant="15" id="16o-7q-hZF"/>
-                    <constraint firstItem="6pQ-OD-SEB" firstAttribute="leading" secondItem="cp0-I6-JZO" secondAttribute="trailing" constant="8" id="4OZ-U6-fCh"/>
-                    <constraint firstAttribute="trailing" secondItem="gQE-zL-xxH" secondAttribute="trailing" constant="15" id="89B-8U-mgC"/>
-                    <constraint firstItem="ajq-lL-NRj" firstAttribute="top" secondItem="6pQ-OD-SEB" secondAttribute="bottom" constant="3" id="G11-xm-kwB"/>
-                    <constraint firstAttribute="bottom" secondItem="gQE-zL-xxH" secondAttribute="bottom" constant="8" id="IaG-CR-IVZ"/>
+                    <constraint firstItem="cp0-I6-JZO" firstAttribute="leading" secondItem="3Qk-c8-3ba" secondAttribute="leading" constant="16" id="16o-7q-hZF"/>
+                    <constraint firstItem="6pQ-OD-SEB" firstAttribute="leading" secondItem="cp0-I6-JZO" secondAttribute="trailing" constant="16" id="4OZ-U6-fCh"/>
+                    <constraint firstItem="6pQ-OD-SEB" firstAttribute="top" secondItem="cp0-I6-JZO" secondAttribute="top" id="4fb-zJ-3ey"/>
+                    <constraint firstAttribute="trailing" secondItem="gQE-zL-xxH" secondAttribute="trailing" constant="16" id="89B-8U-mgC"/>
+                    <constraint firstItem="ajq-lL-NRj" firstAttribute="top" secondItem="6pQ-OD-SEB" secondAttribute="bottom" constant="4" id="G11-xm-kwB"/>
+                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="gQE-zL-xxH" secondAttribute="bottom" constant="8" id="IaG-CR-IVZ"/>
                     <constraint firstItem="gQE-zL-xxH" firstAttribute="top" secondItem="ajq-lL-NRj" secondAttribute="bottom" constant="8" id="KdO-c0-C08"/>
-                    <constraint firstItem="cp0-I6-JZO" firstAttribute="top" secondItem="3Qk-c8-3ba" secondAttribute="top" constant="20" id="NHv-yv-J6D"/>
+                    <constraint firstItem="cp0-I6-JZO" firstAttribute="top" secondItem="3Qk-c8-3ba" secondAttribute="top" constant="16" id="NHv-yv-J6D"/>
                     <constraint firstItem="6pQ-OD-SEB" firstAttribute="leading" secondItem="3Qk-c8-3ba" secondAttribute="leading" constant="63" id="TG1-lC-YTa"/>
-                    <constraint firstItem="6pQ-OD-SEB" firstAttribute="top" secondItem="3Qk-c8-3ba" secondAttribute="top" constant="23" id="YqW-8S-bzr"/>
-                    <constraint firstItem="gQE-zL-xxH" firstAttribute="leading" secondItem="cp0-I6-JZO" secondAttribute="trailing" constant="8" id="adj-cy-kOp"/>
-                    <constraint firstItem="ajq-lL-NRj" firstAttribute="leading" secondItem="cp0-I6-JZO" secondAttribute="trailing" constant="8" id="cNB-2F-Q67"/>
-                    <constraint firstAttribute="trailing" secondItem="ajq-lL-NRj" secondAttribute="trailing" constant="20" id="ysN-Jq-6GM"/>
+                    <constraint firstItem="gQE-zL-xxH" firstAttribute="leading" secondItem="cp0-I6-JZO" secondAttribute="trailing" constant="16" id="adj-cy-kOp"/>
+                    <constraint firstItem="ajq-lL-NRj" firstAttribute="leading" secondItem="cp0-I6-JZO" secondAttribute="trailing" constant="16" id="cNB-2F-Q67"/>
                 </constraints>
                 <variation key="default">
                     <mask key="constraints">

--- a/ScalaDays/UI/TableViewCells/SDSponsorsTableViewCell.xib
+++ b/ScalaDays/UI/TableViewCells/SDSponsorsTableViewCell.xib
@@ -1,8 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="13E28" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -10,21 +12,22 @@
         <tableViewCell contentMode="scaleToFill" placeholderIntrinsicWidth="320" placeholderIntrinsicHeight="106" selectionStyle="default" indentationWidth="10" rowHeight="106" id="xMp-Tl-8v2" customClass="SDSponsorsTableViewCell" customModule="ScalaDays" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="106"/>
             <autoresizingMask key="autoresizingMask"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="xMp-Tl-8v2" id="GFj-MW-IIo">
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" tableViewCell="xMp-Tl-8v2" id="GFj-MW-IIo">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="106"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="RAg-1j-A9J">
-                        <rect key="frame" x="15" y="15" width="290" height="75"/>
+                        <rect key="frame" x="16" y="16" width="288" height="75"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="75" id="CdT-Kg-l7r"/>
                         </constraints>
                     </imageView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="RAg-1j-A9J" firstAttribute="top" secondItem="GFj-MW-IIo" secondAttribute="top" constant="15" id="J2r-kP-ooZ"/>
-                    <constraint firstItem="RAg-1j-A9J" firstAttribute="leading" secondItem="GFj-MW-IIo" secondAttribute="leading" constant="15" id="Jb4-SV-FGe"/>
-                    <constraint firstAttribute="bottom" secondItem="RAg-1j-A9J" secondAttribute="bottom" constant="15" id="j7P-FZ-Gju"/>
-                    <constraint firstAttribute="trailing" secondItem="RAg-1j-A9J" secondAttribute="trailing" constant="15" id="wQj-WR-ils"/>
+                    <constraint firstItem="RAg-1j-A9J" firstAttribute="top" secondItem="GFj-MW-IIo" secondAttribute="top" constant="16" id="J2r-kP-ooZ"/>
+                    <constraint firstItem="RAg-1j-A9J" firstAttribute="leading" secondItem="GFj-MW-IIo" secondAttribute="leading" constant="16" id="Jb4-SV-FGe"/>
+                    <constraint firstAttribute="bottom" secondItem="RAg-1j-A9J" secondAttribute="bottom" constant="16" id="j7P-FZ-Gju"/>
+                    <constraint firstAttribute="trailing" secondItem="RAg-1j-A9J" secondAttribute="trailing" constant="16" id="wQj-WR-ils"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>

--- a/ScalaDays/UI/TableViewCells/SDTableHeaderView.swift
+++ b/ScalaDays/UI/TableViewCells/SDTableHeaderView.swift
@@ -18,7 +18,7 @@ import UIKit
 
 class SDTableHeaderView: UIView {
 
-    let kHeaderTextPadding : CGPoint = CGPoint(x: 15, y: 13)
+    let kHeaderTextPadding : CGPoint = CGPoint(x: 16, y: 11)
     let kHeaderTextInitialWidth : CGFloat = 300.0
     let kHeaderTextInitialHeight : CGFloat = 15.0
     
@@ -30,7 +30,7 @@ class SDTableHeaderView: UIView {
         self.backgroundColor = UIColor.appScheduleTimeBlueBackgroundColor()
         lblDate = UILabel(frame: CGRect(x: kHeaderTextPadding.x, y: kHeaderTextPadding.y, width: kHeaderTextInitialWidth, height: kHeaderTextInitialHeight))
         lblDate.backgroundColor = UIColor.clear
-        lblDate.setCustomFont(UIFont.fontHelveticaNeue(13), colorFont: UIColor.white)
+        lblDate.setCustomFont(UIFont.fontHelveticaNeue(15), colorFont: UIColor.white)
         self.addSubview(lblDate)
     }
 


### PR DESCRIPTION
## Details
Android and iOS got together to review the screens for Scala Days side-by-side in an attempt to try and line up design details so the experience is seamless across both platforms for our users.

In this PR we have aligned the padding and normalized the Titles text sizes.
- Set padding to **16dp**
- Set titles to **15px**