### PR TITLE
Remove Localytics in favor of Firebase (Push Notifications)

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -8,6 +8,11 @@ def firebase
   # enabled Analytics
   pod 'Firebase/Analytics'
 
+  # enabled push notifications
+  pod 'Firebase'
+  pod 'Firebase/Messaging'
+  pod 'Firebase/InAppMessaging'
+
   # enabled Crashlytics (Firebase)
   pod 'Fabric', '~> 1.10.2'
   pod 'Crashlytics', '~> 3.14.0'
@@ -17,28 +22,22 @@ def firebase
 end
 
 
-abstract_target 'ScalaDaysPods' do
+target 'ScalaDays' do
+  firebase
+  
   pod 'Alamofire', '~> 5.0'
   pod 'TwitterKit', '3.4.2'
-
-  target 'ScalaDays' do
-    firebase
-
-    # UI
-    pod 'SDWebImage', '~> 3.5'
-    pod 'SVProgressHUD', '~> 1.0'
-    pod 'UIView+AutoLayout', '~> 1.3'
-
-    # QR code library
-    pod 'ZBarSDK', '~> 1.3.1'
-
-    # Miscellaneous Utils
-    pod 'NSDate+TimeAgo', '~> 1.0.2'
-
-    # Push notifications
-    pod 'Localytics', '~> 5.8'
-  end
-
-  target 'ScalaDaysTests' do
+  pod 'ZBarSDK', '~> 1.3.1'
+  
+  # UI
+  pod 'SDWebImage', '~> 3.5'
+  pod 'SVProgressHUD', '~> 1.0'
+  pod 'UIView+AutoLayout', '~> 1.3'
+  
+  # Utils
+  pod 'NSDate+TimeAgo', '~> 1.0.2'
+  
+  target 'ScalaDays Notifications' do
+    inherit! :search_paths
   end
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,6 +3,8 @@ PODS:
   - Crashlytics (3.14.0):
     - Fabric (~> 1.10.2)
   - Fabric (1.10.2)
+  - Firebase (6.21.0):
+    - Firebase/Core (= 6.21.0)
   - Firebase/Analytics (6.21.0):
     - Firebase/Core
   - Firebase/Core (6.21.0):
@@ -10,6 +12,12 @@ PODS:
     - FirebaseAnalytics (= 6.4.0)
   - Firebase/CoreOnly (6.21.0):
     - FirebaseCore (= 6.6.5)
+  - Firebase/InAppMessaging (6.21.0):
+    - Firebase/CoreOnly
+    - FirebaseInAppMessaging (~> 0.19.1)
+  - Firebase/Messaging (6.21.0):
+    - Firebase/CoreOnly
+    - FirebaseMessaging (~> 4.3.0)
   - Firebase/Performance (6.21.0):
     - Firebase/CoreOnly
     - FirebasePerformance (~> 3.1.11)
@@ -39,6 +47,12 @@ PODS:
     - GoogleUtilities/Logger (~> 6.5)
     - nanopb (~> 0.3.901)
   - FirebaseCoreDiagnosticsInterop (1.2.0)
+  - FirebaseInAppMessaging (0.19.1):
+    - FirebaseABTesting (~> 3.2)
+    - FirebaseAnalyticsInterop (~> 1.3)
+    - FirebaseCore (~> 6.2)
+    - FirebaseInstallations (~> 1.1)
+    - GoogleDataTransportCCTSupport (~> 2.0)
   - FirebaseInstallations (1.1.1):
     - FirebaseCore (~> 6.6)
     - GoogleUtilities/UserDefaults (~> 6.5)
@@ -48,6 +62,15 @@ PODS:
     - FirebaseInstallations (~> 1.0)
     - GoogleUtilities/Environment (~> 6.5)
     - GoogleUtilities/UserDefaults (~> 6.5)
+  - FirebaseMessaging (4.3.0):
+    - FirebaseAnalyticsInterop (~> 1.5)
+    - FirebaseCore (~> 6.6)
+    - FirebaseInstanceID (~> 4.3)
+    - GoogleUtilities/AppDelegateSwizzler (~> 6.5)
+    - GoogleUtilities/Environment (~> 6.5)
+    - GoogleUtilities/Reachability (~> 6.5)
+    - GoogleUtilities/UserDefaults (~> 6.5)
+    - Protobuf (>= 3.9.2, ~> 3.9)
   - FirebasePerformance (3.1.11):
     - FirebaseCore (~> 6.6)
     - FirebaseInstallations (~> 1.1)
@@ -102,7 +125,6 @@ PODS:
   - GoogleUtilities/UserDefaults (6.5.2):
     - GoogleUtilities/Logger
   - GTMSessionFetcher/Core (1.3.1)
-  - Localytics (5.8.0)
   - nanopb (0.3.9011):
     - nanopb/decode (= 0.3.9011)
     - nanopb/encode (= 0.3.9011)
@@ -125,9 +147,11 @@ DEPENDENCIES:
   - Alamofire (~> 5.0)
   - Crashlytics (~> 3.14.0)
   - Fabric (~> 1.10.2)
+  - Firebase
   - Firebase/Analytics
+  - Firebase/InAppMessaging
+  - Firebase/Messaging
   - Firebase/Performance
-  - Localytics (~> 5.8)
   - "NSDate+TimeAgo (~> 1.0.2)"
   - SDWebImage (~> 3.5)
   - SVProgressHUD (~> 1.0)
@@ -147,8 +171,10 @@ SPEC REPOS:
     - FirebaseCore
     - FirebaseCoreDiagnostics
     - FirebaseCoreDiagnosticsInterop
+    - FirebaseInAppMessaging
     - FirebaseInstallations
     - FirebaseInstanceID
+    - FirebaseMessaging
     - FirebasePerformance
     - FirebaseRemoteConfig
     - GoogleAppMeasurement
@@ -157,7 +183,6 @@ SPEC REPOS:
     - GoogleToolboxForMac
     - GoogleUtilities
     - GTMSessionFetcher
-    - Localytics
     - nanopb
     - "NSDate+TimeAgo"
     - PromisesObjC
@@ -180,8 +205,10 @@ SPEC CHECKSUMS:
   FirebaseCore: 9f495d3afacb7b558711e6218ebb14b1c51b5802
   FirebaseCoreDiagnostics: e9b4cd8ba60dee0f2d13347332e4b7898cca5b61
   FirebaseCoreDiagnosticsInterop: 296e2c5f5314500a850ad0b83e9e7c10b011a850
+  FirebaseInAppMessaging: 297660b3706fdb1ec86c11abd0597ca3ae578b5d
   FirebaseInstallations: acb3216eb9784d3b1d2d2d635ff74fa892cc0c44
   FirebaseInstanceID: 7ee0d6777013bb952f377b41965bf132b6a075be
+  FirebaseMessaging: 4ec33842d36b3319e062e51fb8b35a74f726950d
   FirebasePerformance: 5652d2004001e886da6dca04f478c695f87c4702
   FirebaseRemoteConfig: 47abf7a04a9082091955ea555aa79cfdd249b19c
   GoogleAppMeasurement: 6e68a94d0eaeb1d73ef6b0ed4f7334e29d63ae29
@@ -190,7 +217,6 @@ SPEC CHECKSUMS:
   GoogleToolboxForMac: 800648f8b3127618c1b59c7f97684427630c5ea3
   GoogleUtilities: ad0f3b691c67909d03a3327cc205222ab8f42e0e
   GTMSessionFetcher: cea130bbfe5a7edc8d06d3f0d17288c32ffe9925
-  Localytics: c7db3c2790f739b0dc4ea1462bf378bff1dceabf
   nanopb: 18003b5e52dab79db540fe93fe9579f399bd1ccd
   "NSDate+TimeAgo": 35601c619b2d59290055e4fe76e61d97677a2360
   PromisesObjC: c119f3cd559f50b7ae681fa59dc1acd19173b7e6
@@ -202,6 +228,6 @@ SPEC CHECKSUMS:
   "UIView+AutoLayout": d5f741a74b68fa27f97fdf24b08a2497e0e957db
   ZBarSDK: 4c1b5daeb7d6cc67dc9355e690af0230a661f6ec
 
-PODFILE CHECKSUM: d45f9893581c93073173b18b2dfdfa210a35dbef
+PODFILE CHECKSUM: 645b5b60760859937989ea5fa6e4459d0225e226
 
 COCOAPODS: 1.9.1

--- a/README.md
+++ b/README.md
@@ -15,14 +15,11 @@ Once the dependencies are downloaded Cocoapods will create a workspace file. Use
 
 ## External Keys
 
-As this project uses Localytics, TwitterKit and Firebase (Analytics + Crashlytics) two external plist files, located in the *External/Keys* folder, are used to store the API keys for those services.
-You need to provide both files (not included in the repository for security reasons)
+As this project uses TwitterKit and Firebase (Analytics + Crashlytics + Cloud Messaging) frameworks, you need to provide the whole API keys (not included in the repo for security reasons). They are distributed in two external `plist files`, located in the *External/Keys* folder.
 
 **SDExternalKeys.plist**
 
 	<dict>
-		<key>Localytics</key>
-		<string>***********</string>
 		<key>TwitterConsumerKey</key>
 		<string>***********</string>
 		<key>TwitterConsumerSecret</key>
@@ -33,28 +30,9 @@ You need to provide both files (not included in the repository for security reas
 
 You can find this plist in your [Firebase console](https://firebase.google.com/).
 
-## Push Notifications
-
-Scala Days has a minimum time between network calls of **four hours**. To override this limit you can send a push notification with the following json key/value pair:
-
-	jsonReload : true
-
-For example, in our case :
-
-	{"aps":
-		{
-		 "alert":" Scala Days just added a new event"
-		 },
-	"jsonReload": true
-	}
-
 ## Crash Reporting
 
-Crash reporting is handled through Crashlytics. All uncaught exceptions are sent to Crashlytics.
-
-## Functional code
-
-By using Swift in the development of this project we’ve had the chance to bring some **functional programming** aspects to it, i.e.: pattern matching, use of higher-order functions, immutability (wherever possible, Swift 1.2 will let us improve this area further). We consider the Scala Days project as our little first step in the way towards an even more functional development in Apple’s platforms, a target we’re deeply committed to. For a deeper look to what Swift and Scala have in common (in our humble opinion) please refer to this [blog post](http://www.47deg.com/blog/swift-scala).
+Crash reporting is handled through Crashlytics. All uncaught exceptions are sent to Firebase/Crashlytics.
 
 ## License
 Copyright (C) 2015 47 Degrees, LLC http://47deg.com hello@47deg.com

--- a/ScalaDays Notifications/Info.plist
+++ b/ScalaDays Notifications/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/ScalaDays Notifications/Info.plist
+++ b/ScalaDays Notifications/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>ScalaDays Notifications</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.usernotifications.service</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).NotificationService</string>
+	</dict>
+</dict>
+</plist>

--- a/ScalaDays Notifications/NotificationService.swift
+++ b/ScalaDays Notifications/NotificationService.swift
@@ -1,0 +1,22 @@
+import UserNotifications
+import FirebaseMessaging
+
+class NotificationService: UNNotificationServiceExtension {
+    var contentHandler: ((UNNotificationContent) -> Void)?
+    var bestAttemptContent: UNMutableNotificationContent?
+
+    override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
+        guard let content = request.content.mutableCopy() as? UNMutableNotificationContent else { return }
+        self.contentHandler = contentHandler
+        self.bestAttemptContent = content
+        
+        FIRMessagingExtensionHelper().populateNotificationContent(content, withContentHandler: contentHandler)
+    }
+    
+    override func serviceExtensionTimeWillExpire() {
+        guard let contentHandler = contentHandler,
+              let bestAttemptContent =  bestAttemptContent else { return }
+        
+        contentHandler(bestAttemptContent)
+    }
+}

--- a/ScalaDays.xcodeproj/project.pbxproj
+++ b/ScalaDays.xcodeproj/project.pbxproj
@@ -1196,7 +1196,7 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CODE_SIGN_ENTITLEMENTS = ScalaDays/ScalaDays.entitlements;
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				DEVELOPMENT_TEAM = P548S5LU96;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1253,11 +1253,13 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 33;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = P548S5LU96;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "ScalaDays Notifications/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MARKETING_VERSION = 3.2.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.fortysevendeg.scaladays.ScalaDays-Notifications";
@@ -1279,11 +1281,13 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 33;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = P548S5LU96;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "ScalaDays Notifications/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MARKETING_VERSION = 3.2.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.fortysevendeg.scaladays.ScalaDays-Notifications";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1303,11 +1307,13 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 33;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = P548S5LU96;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "ScalaDays Notifications/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MARKETING_VERSION = 3.2.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.fortysevendeg.scaladays.ScalaDays-Notifications";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1439,7 +1445,7 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CODE_SIGN_ENTITLEMENTS = ScalaDays/ScalaDays.entitlements;
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				DEVELOPMENT_TEAM = P548S5LU96;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1469,7 +1475,7 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CODE_SIGN_ENTITLEMENTS = ScalaDays/ScalaDays.entitlements;
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				DEVELOPMENT_TEAM = P548S5LU96;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ScalaDays.xcodeproj/project.pbxproj
+++ b/ScalaDays.xcodeproj/project.pbxproj
@@ -1161,7 +1161,8 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
-				COPY_PHASE_STRIP = YES;
+				CODE_SIGN_STYLE = Manual;
+				COPY_PHASE_STRIP = NO;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -1185,6 +1186,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 				VALIDATE_PRODUCT = YES;
+				VALID_ARCHS = "arm64 arm64e armv7s";
 			};
 			name = AdHoc;
 		};
@@ -1353,6 +1355,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -1377,9 +1380,10 @@
 				OTHER_SWIFT_FLAGS = "-D DEBUG";
 				PROVISIONING_PROFILE = "78583264-b056-4bff-9bf5-11006370761d";
 				SDKROOT = iphoneos;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
+				VALID_ARCHS = "arm64 arm64e armv7s";
 			};
 			name = Debug;
 		};
@@ -1414,7 +1418,8 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
-				COPY_PHASE_STRIP = YES;
+				CODE_SIGN_STYLE = Manual;
+				COPY_PHASE_STRIP = NO;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -1434,6 +1439,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 				VALIDATE_PRODUCT = YES;
+				VALID_ARCHS = "arm64 arm64e armv7s";
 			};
 			name = Release;
 		};

--- a/ScalaDays.xcodeproj/project.pbxproj
+++ b/ScalaDays.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		8B5818F12406DA1200587211 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8B5818F02406DA1200587211 /* GoogleService-Info.plist */; };
 		8B5818F42406F8E800587211 /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5818F22406F8E700587211 /* Analytics.swift */; };
 		8B5818F52406F8E800587211 /* FirebaseScalaDays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5818F32406F8E700587211 /* FirebaseScalaDays.swift */; };
+		8B85D82E24375C4D00BF5F3D /* FirebaseNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B85D82D24375C4D00BF5F3D /* FirebaseNotifications.swift */; };
 		8B8AF6BF24129EF7009A8D6C /* TwitterSocialController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8AF6BE24129EF7009A8D6C /* TwitterSocialController.swift */; };
 		8B9F38D9243730C900924A8A /* AppDelegate+PushNoticications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9F38D8243730C900924A8A /* AppDelegate+PushNoticications.swift */; };
 		8B9F38E1243734CB00924A8A /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9F38E0243734CB00924A8A /* NotificationService.swift */; };
@@ -240,6 +241,7 @@
 		8B5818F02406DA1200587211 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = "GoogleService-Info.plist"; path = "ScalaDays/External/GoogleService-Info.plist"; sourceTree = SOURCE_ROOT; };
 		8B5818F22406F8E700587211 /* Analytics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
 		8B5818F32406F8E700587211 /* FirebaseScalaDays.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FirebaseScalaDays.swift; sourceTree = "<group>"; };
+		8B85D82D24375C4D00BF5F3D /* FirebaseNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseNotifications.swift; sourceTree = "<group>"; };
 		8B8AF6BE24129EF7009A8D6C /* TwitterSocialController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwitterSocialController.swift; sourceTree = "<group>"; };
 		8B9F38D8243730C900924A8A /* AppDelegate+PushNoticications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+PushNoticications.swift"; sourceTree = "<group>"; };
 		8B9F38DE243734CB00924A8A /* ScalaDays Notifications.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "ScalaDays Notifications.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -518,6 +520,7 @@
 			isa = PBXGroup;
 			children = (
 				597E3B0F1AB2E5FD00F41F17 /* DataManager.swift */,
+				8B85D82D24375C4D00BF5F3D /* FirebaseNotifications.swift */,
 				8B39E3452408010F00338921 /* NotificationManager.swift */,
 				8B18E251240D214200AED41C /* UserManager.swift */,
 				8BF8205C2407C46D00C1C24E /* Response */,
@@ -1054,6 +1057,7 @@
 				A1FA1FE81A7AA33F00338AF0 /* SDAboutViewController.swift in Sources */,
 				59D174621A8E0C2B001E87CF /* SDSponsorsTableViewCell.swift in Sources */,
 				A1FA1FE01A7AA2FA00338AF0 /* SDSponsorViewController.swift in Sources */,
+				8B85D82E24375C4D00BF5F3D /* FirebaseNotifications.swift in Sources */,
 				5928D1751A88A9FA00E5049E /* SDContactCreationHelper.m in Sources */,
 				593571E91A77DDA8005AA332 /* StoringHelper.swift in Sources */,
 				8BC4E37C2408117300AAA7CE /* SDNotifications.swift in Sources */,
@@ -1258,7 +1262,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.fortysevendeg.scaladays.ScalaDays-Notifications";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "ScalaDays Notification Dev";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_VERSION = 5.0;
 			};
@@ -1283,7 +1287,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.fortysevendeg.scaladays.ScalaDays-Notifications";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "ScalaDays Notification AppStore";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -1307,7 +1311,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.fortysevendeg.scaladays.ScalaDays-Notifications";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "ScalaDays Notification AdHoc";
 				SWIFT_VERSION = 5.0;
 			};
 			name = AdHoc;

--- a/ScalaDays.xcodeproj/project.pbxproj
+++ b/ScalaDays.xcodeproj/project.pbxproj
@@ -10,10 +10,9 @@
 		0D21FB302090ED1200441767 /* TWTRTweet+SDTweet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D21FB2F2090ED1200441767 /* TWTRTweet+SDTweet.swift */; };
 		0D21FB312091F84900441767 /* TWTRTweet+SDTweet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D21FB2F2090ED1200441767 /* TWTRTweet+SDTweet.swift */; };
 		0DEDC40E20AC7197004C7643 /* VoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DEDC40D20AC7197004C7643 /* VoteTests.swift */; };
-		12E3C2517E2B2D10F7D9FEA8 /* Pods_ScalaDaysPods_ScalaDays.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 857E5518A29D51062F9155B4 /* Pods_ScalaDaysPods_ScalaDays.framework */; };
-		18DAE816976C232E95E125FE /* Pods_ScalaDaysPods_ScalaDaysTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7DE3E72A5ED11E640A8CD7A9 /* Pods_ScalaDaysPods_ScalaDaysTests.framework */; };
 		1EA75E8B1A925BFF00884EC8 /* SDConferenceTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EA75E891A925BFF00884EC8 /* SDConferenceTableViewCell.swift */; };
 		1EA75E8C1A925BFF00884EC8 /* SDConferenceTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1EA75E8A1A925BFF00884EC8 /* SDConferenceTableViewCell.xib */; };
+		39036EAE63064913990C96C3 /* Pods_ScalaDays_Notifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D960E86E02CD5B9889AF42A6 /* Pods_ScalaDays_Notifications.framework */; };
 		590DDD6A1A83BAC100E4CC3F /* SDSpeakersListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 590DDD691A83BAC100E4CC3F /* SDSpeakersListViewController.swift */; };
 		590DDD6E1A83BAFD00E4CC3F /* SDSpeakersListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 590DDD6D1A83BAFD00E4CC3F /* SDSpeakersListViewController.xib */; };
 		590DDD701A83BE9B00E4CC3F /* SDSpeakersTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 590DDD6F1A83BE9B00E4CC3F /* SDSpeakersTableViewCell.swift */; };
@@ -89,6 +88,9 @@
 		8B5818F42406F8E800587211 /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5818F22406F8E700587211 /* Analytics.swift */; };
 		8B5818F52406F8E800587211 /* FirebaseScalaDays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5818F32406F8E700587211 /* FirebaseScalaDays.swift */; };
 		8B8AF6BF24129EF7009A8D6C /* TwitterSocialController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8AF6BE24129EF7009A8D6C /* TwitterSocialController.swift */; };
+		8B9F38D9243730C900924A8A /* AppDelegate+PushNoticications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9F38D8243730C900924A8A /* AppDelegate+PushNoticications.swift */; };
+		8B9F38E1243734CB00924A8A /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9F38E0243734CB00924A8A /* NotificationService.swift */; };
+		8B9F38E5243734CB00924A8A /* ScalaDays Notifications.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 8B9F38DE243734CB00924A8A /* ScalaDays Notifications.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		8BC4E37C2408117300AAA7CE /* SDNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC4E37B2408117300AAA7CE /* SDNotifications.swift */; };
 		8BC4E37E240814E700AAA7CE /* DateFormatter+Decoders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC4E37D240814E700AAA7CE /* DateFormatter+Decoders.swift */; };
 		A13B434520AC773A00F78759 /* SDExternalKeys.plist in Resources */ = {isa = PBXBuildFile; fileRef = A13B434420AC773A00F78759 /* SDExternalKeys.plist */; };
@@ -122,9 +124,17 @@
 		A1FA1FF61A7B98FE00338AF0 /* SDSlideMenuViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = A1CC72141A7A727F00757B65 /* SDSlideMenuViewController.xib */; };
 		A1FA1FF91A7BA95500338AF0 /* SDConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FA1FF81A7BA95500338AF0 /* SDConstants.swift */; };
 		A1FA1FFB1A7BAE5B00338AF0 /* SDFonts.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FA1FFA1A7BAE5B00338AF0 /* SDFonts.swift */; };
+		C516D5BD48401C99524A22E9 /* Pods_ScalaDays.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A536D60380EF52CB5F59C3DA /* Pods_ScalaDays.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		8B9F38E3243734CB00924A8A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A1D795BF1A68267F009CCEB3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8B9F38DD243734CB00924A8A;
+			remoteInfo = "ScalaDays Notifications";
+		};
 		A1D795DD1A68267F009CCEB3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = A1D795BF1A68267F009CCEB3 /* Project object */;
@@ -135,6 +145,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		8B9F38EA243734CB00924A8A /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				8B9F38E5243734CB00924A8A /* ScalaDays Notifications.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A163DC141A6D6C7C00A21B8E /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -148,13 +169,14 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		0256E37AB85427EDF899EF98 /* Pods-ScalaDaysPods-ScalaDaysTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ScalaDaysPods-ScalaDaysTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ScalaDaysPods-ScalaDaysTests/Pods-ScalaDaysPods-ScalaDaysTests.debug.xcconfig"; sourceTree = "<group>"; };
+		0287199FDEB787EA163C309E /* Pods-ScalaDays Notifications.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ScalaDays Notifications.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ScalaDays Notifications/Pods-ScalaDays Notifications.debug.xcconfig"; sourceTree = "<group>"; };
 		02C3CA31C911ADCA6C7CA1B8 /* Pods-ScalaDaysPods-ScalaDays.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ScalaDaysPods-ScalaDays.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ScalaDaysPods-ScalaDays/Pods-ScalaDaysPods-ScalaDays.debug.xcconfig"; sourceTree = "<group>"; };
 		0D21FB2F2090ED1200441767 /* TWTRTweet+SDTweet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TWTRTweet+SDTweet.swift"; sourceTree = "<group>"; };
 		0DEDC40D20AC7197004C7643 /* VoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoteTests.swift; sourceTree = "<group>"; };
 		1EA75E891A925BFF00884EC8 /* SDConferenceTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SDConferenceTableViewCell.swift; sourceTree = "<group>"; };
 		1EA75E8A1A925BFF00884EC8 /* SDConferenceTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SDConferenceTableViewCell.xib; sourceTree = "<group>"; };
-		27CC132DAC4EB8C5D5F3EC28 /* Pods-ScalaDaysPods-ScalaDaysTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ScalaDaysPods-ScalaDaysTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ScalaDaysPods-ScalaDaysTests/Pods-ScalaDaysPods-ScalaDaysTests.release.xcconfig"; sourceTree = "<group>"; };
+		4DFA1B90D4E247FCC9E09CA0 /* Pods-ScalaDays Notifications.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ScalaDays Notifications.release.xcconfig"; path = "Pods/Target Support Files/Pods-ScalaDays Notifications/Pods-ScalaDays Notifications.release.xcconfig"; sourceTree = "<group>"; };
+		50A5C2BB4BFDDAB0A3D445DB /* Pods-ScalaDays Notifications.adhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ScalaDays Notifications.adhoc.xcconfig"; path = "Pods/Target Support Files/Pods-ScalaDays Notifications/Pods-ScalaDays Notifications.adhoc.xcconfig"; sourceTree = "<group>"; };
 		590DDD691A83BAC100E4CC3F /* SDSpeakersListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SDSpeakersListViewController.swift; sourceTree = "<group>"; };
 		590DDD6D1A83BAFD00E4CC3F /* SDSpeakersListViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SDSpeakersListViewController.xib; sourceTree = "<group>"; };
 		590DDD6F1A83BE9B00E4CC3F /* SDSpeakersTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SDSpeakersTableViewCell.swift; sourceTree = "<group>"; };
@@ -199,8 +221,7 @@
 		59D174611A8E0C2B001E87CF /* SDSponsorsTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SDSponsorsTableViewCell.swift; sourceTree = "<group>"; };
 		59D174631A8E0C3A001E87CF /* SDSponsorsTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SDSponsorsTableViewCell.xib; sourceTree = "<group>"; };
 		59F0E2E51CA1518700BDD40E /* Vote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Vote.swift; sourceTree = "<group>"; };
-		7DE3E72A5ED11E640A8CD7A9 /* Pods_ScalaDaysPods_ScalaDaysTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ScalaDaysPods_ScalaDaysTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		857E5518A29D51062F9155B4 /* Pods_ScalaDaysPods_ScalaDays.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ScalaDaysPods_ScalaDays.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		679E8210A12478E88B514A2B /* Pods-ScalaDays.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ScalaDays.release.xcconfig"; path = "Pods/Target Support Files/Pods-ScalaDays/Pods-ScalaDays.release.xcconfig"; sourceTree = "<group>"; };
 		8B02A9AA240E9A87006CD991 /* UserDefaults+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Extension.swift"; sourceTree = "<group>"; };
 		8B18E251240D214200AED41C /* UserManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserManager.swift; sourceTree = "<group>"; };
 		8B18E255240D251100AED41C /* Array+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extension.swift"; sourceTree = "<group>"; };
@@ -220,6 +241,10 @@
 		8B5818F22406F8E700587211 /* Analytics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
 		8B5818F32406F8E700587211 /* FirebaseScalaDays.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FirebaseScalaDays.swift; sourceTree = "<group>"; };
 		8B8AF6BE24129EF7009A8D6C /* TwitterSocialController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwitterSocialController.swift; sourceTree = "<group>"; };
+		8B9F38D8243730C900924A8A /* AppDelegate+PushNoticications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+PushNoticications.swift"; sourceTree = "<group>"; };
+		8B9F38DE243734CB00924A8A /* ScalaDays Notifications.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "ScalaDays Notifications.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		8B9F38E0243734CB00924A8A /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
+		8B9F38E2243734CB00924A8A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8BC4E37B2408117300AAA7CE /* SDNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDNotifications.swift; sourceTree = "<group>"; };
 		8BC4E37D240814E700AAA7CE /* DateFormatter+Decoders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Decoders.swift"; sourceTree = "<group>"; };
 		9A5C79BA0AC4A59C8B4E657E /* Pods-ScalaDaysPods-ScalaDays.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ScalaDaysPods-ScalaDays.release.xcconfig"; path = "Pods/Target Support Files/Pods-ScalaDaysPods-ScalaDays/Pods-ScalaDaysPods-ScalaDays.release.xcconfig"; sourceTree = "<group>"; };
@@ -260,17 +285,28 @@
 		A1FA1FEA1A7AA6AF00338AF0 /* SDColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SDColor.swift; sourceTree = "<group>"; };
 		A1FA1FF81A7BA95500338AF0 /* SDConstants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SDConstants.swift; sourceTree = "<group>"; };
 		A1FA1FFA1A7BAE5B00338AF0 /* SDFonts.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SDFonts.swift; sourceTree = "<group>"; };
+		A536D60380EF52CB5F59C3DA /* Pods_ScalaDays.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ScalaDays.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A81D14EFE1A576D550FC603B /* Pods-ScalaDays.adhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ScalaDays.adhoc.xcconfig"; path = "Pods/Target Support Files/Pods-ScalaDays/Pods-ScalaDays.adhoc.xcconfig"; sourceTree = "<group>"; };
 		ABF9038973313EDBBD18EB45 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB0D16F53D7B0C5B9108F6C9 /* Pods-ScalaDaysPods-ScalaDays.adhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ScalaDaysPods-ScalaDays.adhoc.xcconfig"; path = "Pods/Target Support Files/Pods-ScalaDaysPods-ScalaDays/Pods-ScalaDaysPods-ScalaDays.adhoc.xcconfig"; sourceTree = "<group>"; };
-		CC4723C7FE05D67C9D7678CD /* Pods-ScalaDaysPods-ScalaDaysTests.adhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ScalaDaysPods-ScalaDaysTests.adhoc.xcconfig"; path = "Pods/Target Support Files/Pods-ScalaDaysPods-ScalaDaysTests/Pods-ScalaDaysPods-ScalaDaysTests.adhoc.xcconfig"; sourceTree = "<group>"; };
+		D960E86E02CD5B9889AF42A6 /* Pods_ScalaDays_Notifications.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ScalaDays_Notifications.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DFB6C80ED129C13C97CA921D /* Pods-ScalaDays.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ScalaDays.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ScalaDays/Pods-ScalaDays.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		8B9F38DB243734CB00924A8A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				39036EAE63064913990C96C3 /* Pods_ScalaDays_Notifications.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A1D795C41A68267F009CCEB3 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				12E3C2517E2B2D10F7D9FEA8 /* Pods_ScalaDaysPods_ScalaDays.framework in Frameworks */,
+				C516D5BD48401C99524A22E9 /* Pods_ScalaDays.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -278,7 +314,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				18DAE816976C232E95E125FE /* Pods_ScalaDaysPods_ScalaDaysTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -517,8 +552,8 @@
 				595003001A84C1DA00A1C24F /* MobileCoreServices.framework */,
 				A163DC2E1A6E595B00A21B8E /* libPods-SwiftyJSON.a */,
 				ABF9038973313EDBBD18EB45 /* Pods.framework */,
-				857E5518A29D51062F9155B4 /* Pods_ScalaDaysPods_ScalaDays.framework */,
-				7DE3E72A5ED11E640A8CD7A9 /* Pods_ScalaDaysPods_ScalaDaysTests.framework */,
+				A536D60380EF52CB5F59C3DA /* Pods_ScalaDays.framework */,
+				D960E86E02CD5B9889AF42A6 /* Pods_ScalaDays_Notifications.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -530,6 +565,15 @@
 				8B27271124095F9100103EFF /* UITableView+Cells.swift */,
 			);
 			path = Utils;
+			sourceTree = "<group>";
+		};
+		8B9F38DF243734CB00924A8A /* ScalaDays Notifications */ = {
+			isa = PBXGroup;
+			children = (
+				8B9F38E0243734CB00924A8A /* NotificationService.swift */,
+				8B9F38E2243734CB00924A8A /* Info.plist */,
+			);
+			path = "ScalaDays Notifications";
 			sourceTree = "<group>";
 		};
 		8BC4E37F240814F400AAA7CE /* Extensions */ = {
@@ -553,6 +597,7 @@
 			children = (
 				A1D795C91A68267F009CCEB3 /* ScalaDays */,
 				A1D795DF1A68267F009CCEB3 /* ScalaDaysTests */,
+				8B9F38DF243734CB00924A8A /* ScalaDays Notifications */,
 				A1D795C81A68267F009CCEB3 /* Products */,
 				6DBA1EBEE9CFF41D967A4DF1 /* Frameworks */,
 				D06138476345BCEDEC247207 /* Pods */,
@@ -564,6 +609,7 @@
 			children = (
 				A1D795C71A68267F009CCEB3 /* ScalaDays.app */,
 				A1D795DC1A68267F009CCEB3 /* ScalaDaysTests.xctest */,
+				8B9F38DE243734CB00924A8A /* ScalaDays Notifications.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -574,6 +620,7 @@
 				A1AB2E9A1E893C4E00CFE768 /* ScalaDays.entitlements */,
 				A17D3AC71A690E3A00024062 /* Bridging-Header.h */,
 				A1D795CC1A68267F009CCEB3 /* AppDelegate.swift */,
+				8B9F38D8243730C900924A8A /* AppDelegate+PushNoticications.swift */,
 				A1D795D31A68267F009CCEB3 /* Images.xcassets */,
 				597E3B041AB2E58A00F41F17 /* Models */,
 				597E3B0E1AB2E5FD00F41F17 /* Service */,
@@ -622,10 +669,13 @@
 			children = (
 				02C3CA31C911ADCA6C7CA1B8 /* Pods-ScalaDaysPods-ScalaDays.debug.xcconfig */,
 				9A5C79BA0AC4A59C8B4E657E /* Pods-ScalaDaysPods-ScalaDays.release.xcconfig */,
-				0256E37AB85427EDF899EF98 /* Pods-ScalaDaysPods-ScalaDaysTests.debug.xcconfig */,
-				27CC132DAC4EB8C5D5F3EC28 /* Pods-ScalaDaysPods-ScalaDaysTests.release.xcconfig */,
 				CB0D16F53D7B0C5B9108F6C9 /* Pods-ScalaDaysPods-ScalaDays.adhoc.xcconfig */,
-				CC4723C7FE05D67C9D7678CD /* Pods-ScalaDaysPods-ScalaDaysTests.adhoc.xcconfig */,
+				DFB6C80ED129C13C97CA921D /* Pods-ScalaDays.debug.xcconfig */,
+				679E8210A12478E88B514A2B /* Pods-ScalaDays.release.xcconfig */,
+				A81D14EFE1A576D550FC603B /* Pods-ScalaDays.adhoc.xcconfig */,
+				0287199FDEB787EA163C309E /* Pods-ScalaDays Notifications.debug.xcconfig */,
+				4DFA1B90D4E247FCC9E09CA0 /* Pods-ScalaDays Notifications.release.xcconfig */,
+				50A5C2BB4BFDDAB0A3D445DB /* Pods-ScalaDays Notifications.adhoc.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -633,6 +683,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		8B9F38DD243734CB00924A8A /* ScalaDays Notifications */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8B9F38E6243734CB00924A8A /* Build configuration list for PBXNativeTarget "ScalaDays Notifications" */;
+			buildPhases = (
+				E8B48D7B0E635F3D73E4965A /* [CP] Check Pods Manifest.lock */,
+				8B9F38DA243734CB00924A8A /* Sources */,
+				8B9F38DB243734CB00924A8A /* Frameworks */,
+				8B9F38DC243734CB00924A8A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "ScalaDays Notifications";
+			productName = "ScalaDays Notifications";
+			productReference = 8B9F38DE243734CB00924A8A /* ScalaDays Notifications.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		A1D795C61A68267F009CCEB3 /* ScalaDays */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = A1D795E61A68267F009CCEB3 /* Build configuration list for PBXNativeTarget "ScalaDays" */;
@@ -646,10 +714,12 @@
 				4ABA015E8B8A751D0D8829A2 /* [CP] Embed Pods Frameworks */,
 				3121FD84F860465807A09E8E /* [CP] Copy Pods Resources */,
 				8BAF4ADA241A4195009653FC /* DSYMs */,
+				8B9F38EA243734CB00924A8A /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				8B9F38E4243734CB00924A8A /* PBXTargetDependency */,
 			);
 			name = ScalaDays;
 			productName = ScalaDays;
@@ -660,12 +730,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = A1D795E91A68267F009CCEB3 /* Build configuration list for PBXNativeTarget "ScalaDaysTests" */;
 			buildPhases = (
-				335B04AA5CFE12E35FEF219F /* [CP] Check Pods Manifest.lock */,
 				A1D795D81A68267F009CCEB3 /* Sources */,
 				A1D795D91A68267F009CCEB3 /* Frameworks */,
 				A1D795DA1A68267F009CCEB3 /* Resources */,
-				F08C9BFD17F15CD0A11F13FD /* [CP] Embed Pods Frameworks */,
-				5917D74B01E4D29CAD47F4D5 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -684,10 +751,14 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftMigration = 0720;
-				LastSwiftUpdateCheck = 0930;
+				LastSwiftUpdateCheck = 1140;
 				LastUpgradeCheck = 1130;
 				ORGANIZATIONNAME = "47 Degrees";
 				TargetAttributes = {
+					8B9F38DD243734CB00924A8A = {
+						CreatedOnToolsVersion = 11.4;
+						ProvisioningStyle = Manual;
+					};
 					A1D795C61A68267F009CCEB3 = {
 						CreatedOnToolsVersion = 6.1.1;
 						LastSwiftMigration = 1130;
@@ -724,11 +795,19 @@
 			targets = (
 				A1D795C61A68267F009CCEB3 /* ScalaDays */,
 				A1D795DB1A68267F009CCEB3 /* ScalaDaysTests */,
+				8B9F38DD243734CB00924A8A /* ScalaDays Notifications */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		8B9F38DC243734CB00924A8A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A1D795C51A68267F009CCEB3 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -782,34 +861,18 @@
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ScalaDaysPods-ScalaDays/Pods-ScalaDaysPods-ScalaDays-resources.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-ScalaDays/Pods-ScalaDays-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/FirebaseInAppMessaging/InAppMessagingDisplayResources.bundle",
 				"${PODS_ROOT}/TwitterKit/iOS/TwitterKit.framework/TwitterKitResources.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/InAppMessagingDisplayResources.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/TwitterKitResources.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ScalaDaysPods-ScalaDays/Pods-ScalaDaysPods-ScalaDays-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		335B04AA5CFE12E35FEF219F /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-ScalaDaysPods-ScalaDaysTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ScalaDays/Pods-ScalaDays-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		4ABA015E8B8A751D0D8829A2 /* [CP] Embed Pods Frameworks */ = {
@@ -818,19 +881,18 @@
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ScalaDaysPods-ScalaDays/Pods-ScalaDaysPods-ScalaDays-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-ScalaDays/Pods-ScalaDays-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
-				"${PODS_ROOT}/TwitterCore/iOS/TwitterCore.framework",
-				"${PODS_ROOT}/TwitterKit/iOS/TwitterKit.framework",
 				"${BUILT_PRODUCTS_DIR}/GTMSessionFetcher/GTMSessionFetcher.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleToolboxForMac/GoogleToolboxForMac.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleUtilities/GoogleUtilities.framework",
-				"${PODS_ROOT}/Localytics/Localytics-iOS-5.8.0/Localytics.framework",
 				"${BUILT_PRODUCTS_DIR}/NSDate+TimeAgo/NSDate_TimeAgo.framework",
 				"${BUILT_PRODUCTS_DIR}/PromisesObjC/FBLPromises.framework",
 				"${BUILT_PRODUCTS_DIR}/Protobuf/protobuf.framework",
 				"${BUILT_PRODUCTS_DIR}/SDWebImage/SDWebImage.framework",
 				"${BUILT_PRODUCTS_DIR}/SVProgressHUD/SVProgressHUD.framework",
+				"${PODS_ROOT}/TwitterCore/iOS/TwitterCore.framework",
+				"${PODS_ROOT}/TwitterKit/iOS/TwitterKit.framework",
 				"${BUILT_PRODUCTS_DIR}/UIView+AutoLayout/UIView_AutoLayout.framework",
 				"${BUILT_PRODUCTS_DIR}/ZBarSDK/ZBarSDK.framework",
 				"${BUILT_PRODUCTS_DIR}/nanopb/nanopb.framework",
@@ -838,42 +900,23 @@
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TwitterCore.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TwitterKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMSessionFetcher.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleToolboxForMac.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleUtilities.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Localytics.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/NSDate_TimeAgo.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBLPromises.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/protobuf.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImage.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SVProgressHUD.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TwitterCore.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TwitterKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/UIView_AutoLayout.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZBarSDK.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/nanopb.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ScalaDaysPods-ScalaDays/Pods-ScalaDaysPods-ScalaDays-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		5917D74B01E4D29CAD47F4D5 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ScalaDaysPods-ScalaDaysTests/Pods-ScalaDaysPods-ScalaDaysTests-resources.sh",
-				"${PODS_ROOT}/TwitterKit/iOS/TwitterKit.framework/TwitterKitResources.bundle",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/TwitterKitResources.bundle",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ScalaDaysPods-ScalaDaysTests/Pods-ScalaDaysPods-ScalaDaysTests-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ScalaDays/Pods-ScalaDays-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		8BAF4ADA241A4195009653FC /* DSYMs */ = {
@@ -907,26 +950,26 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Fabric/run\" 650c56fa5bc6a759a4802ae63f430cfaf6c8158a 2c56ab5ccb4f21cd496c8f733a95205cb91e19601dadd81a60e13f963f31c19c\n";
 		};
-		F08C9BFD17F15CD0A11F13FD /* [CP] Embed Pods Frameworks */ = {
+		E8B48D7B0E635F3D73E4965A /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ScalaDaysPods-ScalaDaysTests/Pods-ScalaDaysPods-ScalaDaysTests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
-				"${PODS_ROOT}/TwitterCore/iOS/TwitterCore.framework",
-				"${PODS_ROOT}/TwitterKit/iOS/TwitterKit.framework",
+			inputFileListPaths = (
 			);
-			name = "[CP] Embed Pods Frameworks";
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TwitterCore.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TwitterKit.framework",
+				"$(DERIVED_FILE_DIR)/Pods-ScalaDays Notifications-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ScalaDaysPods-ScalaDaysTests/Pods-ScalaDaysPods-ScalaDaysTests-frameworks.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		F8B581528B7986FBD4884AF5 /* [CP] Check Pods Manifest.lock */ = {
@@ -940,7 +983,7 @@
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-ScalaDaysPods-ScalaDays-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-ScalaDays-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -950,6 +993,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		8B9F38DA243734CB00924A8A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8B9F38E1243734CB00924A8A /* NotificationService.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A1D795C31A68267F009CCEB3 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -995,6 +1046,7 @@
 				595003061A84DE2600A1C24F /* SDQRScannerOverlayView.swift in Sources */,
 				5920EA661A94B20800564014 /* SDMenuControllerItem.swift in Sources */,
 				A1FA1FEB1A7AA6AF00338AF0 /* SDColor.swift in Sources */,
+				8B9F38D9243730C900924A8A /* AppDelegate+PushNoticications.swift in Sources */,
 				8B27271424095FE100103EFF /* Bundle+Extension.swift in Sources */,
 				593223C61A837C6A009189C0 /* SDAlertViewHelper.swift in Sources */,
 				5928D17C1A88F53900E5049E /* SDString+RemoveWhiteSpaces.swift in Sources */,
@@ -1050,6 +1102,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		8B9F38E4243734CB00924A8A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8B9F38DD243734CB00924A8A /* ScalaDays Notifications */;
+			targetProxy = 8B9F38E3243734CB00924A8A /* PBXContainerItemProxy */;
+		};
 		A1D795DE1A68267F009CCEB3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = A1D795C61A68267F009CCEB3 /* ScalaDays */;
@@ -1129,7 +1186,7 @@
 		};
 		8B02A9A8240E996D006CD991 /* AdHoc */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CB0D16F53D7B0C5B9108F6C9 /* Pods-ScalaDaysPods-ScalaDays.adhoc.xcconfig */;
+			baseConfigurationReference = A81D14EFE1A576D550FC603B /* Pods-ScalaDays.adhoc.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -1159,7 +1216,6 @@
 		};
 		8B02A9A9240E996D006CD991 /* AdHoc */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CC4723C7FE05D67C9D7678CD /* Pods-ScalaDaysPods-ScalaDaysTests.adhoc.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Manual;
@@ -1179,6 +1235,80 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ScalaDays.app/ScalaDays";
+			};
+			name = AdHoc;
+		};
+		8B9F38E7243734CB00924A8A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0287199FDEB787EA163C309E /* Pods-ScalaDays Notifications.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Manual;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = P548S5LU96;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "ScalaDays Notifications/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.fortysevendeg.scaladays.ScalaDays-Notifications";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		8B9F38E8243734CB00924A8A /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4DFA1B90D4E247FCC9E09CA0 /* Pods-ScalaDays Notifications.release.xcconfig */;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Manual;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = P548S5LU96;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "ScalaDays Notifications/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.fortysevendeg.scaladays.ScalaDays-Notifications";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		8B9F38E9243734CB00924A8A /* AdHoc */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 50A5C2BB4BFDDAB0A3D445DB /* Pods-ScalaDays Notifications.adhoc.xcconfig */;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Manual;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = P548S5LU96;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "ScalaDays Notifications/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.fortysevendeg.scaladays.ScalaDays-Notifications";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
 			};
 			name = AdHoc;
 		};
@@ -1299,7 +1429,7 @@
 		};
 		A1D795E71A68267F009CCEB3 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 02C3CA31C911ADCA6C7CA1B8 /* Pods-ScalaDaysPods-ScalaDays.debug.xcconfig */;
+			baseConfigurationReference = DFB6C80ED129C13C97CA921D /* Pods-ScalaDays.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -1329,7 +1459,7 @@
 		};
 		A1D795E81A68267F009CCEB3 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9A5C79BA0AC4A59C8B4E657E /* Pods-ScalaDaysPods-ScalaDays.release.xcconfig */;
+			baseConfigurationReference = 679E8210A12478E88B514A2B /* Pods-ScalaDays.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -1359,7 +1489,6 @@
 		};
 		A1D795EA1A68267F009CCEB3 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0256E37AB85427EDF899EF98 /* Pods-ScalaDaysPods-ScalaDaysTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Manual;
@@ -1388,7 +1517,6 @@
 		};
 		A1D795EB1A68267F009CCEB3 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 27CC132DAC4EB8C5D5F3EC28 /* Pods-ScalaDaysPods-ScalaDaysTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Manual;
@@ -1414,6 +1542,16 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		8B9F38E6243734CB00924A8A /* Build configuration list for PBXNativeTarget "ScalaDays Notifications" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8B9F38E7243734CB00924A8A /* Debug */,
+				8B9F38E8243734CB00924A8A /* Release */,
+				8B9F38E9243734CB00924A8A /* AdHoc */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		A1D795C21A68267F009CCEB3 /* Build configuration list for PBXProject "ScalaDays" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/ScalaDays/AppDelegate+PushNoticications.swift
+++ b/ScalaDays/AppDelegate+PushNoticications.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Firebase
+import UserNotifications
+
+extension AppDelegate: UNUserNotificationCenterDelegate, MessagingDelegate {
+    private static let SHOW_DEVICE_TOKEN = false
+    
+    // MARK: Registration
+    func initializeNotifications(application: UIApplication) {
+        registerPushNotifications(application: application)
+        registerMessaging()
+    }
+    
+    private func registerPushNotifications(application: UIApplication) {
+        UNUserNotificationCenter.current().delegate = self
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { (_, _) in }
+        application.registerForRemoteNotifications()
+    }
+    
+    private func registerMessaging() {
+        Messaging.messaging().delegate = self
+    }
+    
+    // MARK: Push Notifications <delegate>
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        let userInfo = notification.request.content.userInfo
+        show(userInfo: userInfo)
+        completionHandler(.alert)
+    }
+    
+    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        let userInfo = response.notification.request.content.userInfo
+        show(userInfo: userInfo)
+        didTapOnNotification(userInfo: userInfo)
+        completionHandler()
+    }
+    
+    func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+        show(userInfo: userInfo)
+        didTapOnNotification(userInfo: userInfo)
+        completionHandler(.noData)
+    }
+    
+    private func didTapOnNotification(userInfo: [AnyHashable: Any]) {
+        if let jsonReload = userInfo["jsonReload"] as? String, jsonReload.lowercased() == "true" {
+            DataManager.sharedInstance.lastConnectionAttemptDate = nil
+            menuViewController.askControllersToReload()
+        }
+        
+        menuViewController.showNotifications(receivedNotifications: true)
+    }
+    
+    // MARK: Messaging
+    public func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String) {
+        if AppDelegate.SHOW_DEVICE_TOKEN {
+            showDeviceToken()
+            showRegistrationToken()
+        }
+        
+        NotificationCenter.default.post(name: Notification.Name("FCMToken"), object: nil, userInfo: ["token": fcmToken])
+        // Note: This callback is fired at each app startup and whenever a new token is generated.
+        //       If necessary send token to application server.
+    }
+    
+    // MARK: - Helpers
+    private func show(userInfo: [AnyHashable : Any]) {
+        if let messageID = userInfo[UserInfo.gcmMessageIDKey] {
+            print("Message ID: \(messageID)")
+        }
+        
+        print("User Info: \(userInfo)")
+    }
+    
+    private func showRegistrationToken() {
+        InstanceID.instanceID().instanceID { (result, error) in
+            if let error = error {
+                print("Error fetching remote instance ID: \(error)")
+            } else if let result = result {
+                print("Firebase registration token: \(result.token)")
+            }
+        }
+    }
+    
+    private func showDeviceToken() {
+        guard let deviceToken = Messaging.messaging().apnsToken else { return }
+        let deviceTokenString = deviceToken.reduce("", {$0 + String(format: "%02X", $1)})
+        print("DEVICE TOKEN\n------------------\n\(deviceTokenString)\n------------------")
+    }
+    
+    // MARK: - Constants
+    enum UserInfo {
+        static let gcmMessageIDKey = "gcm.message_id"
+    }
+}

--- a/ScalaDays/AppDelegate.swift
+++ b/ScalaDays/AppDelegate.swift
@@ -1,32 +1,13 @@
-/*
-* Copyright (C) 2015 47 Degrees, LLC http://47deg.com hello@47deg.com
-*
-* Licensed under the Apache License, Version 2.0 (the "License"); you may
-* not use this file except in compliance with the License. You may obtain
-* a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
-
 import UIKit
 import SVProgressHUD
-
-import UserNotifications
-import Localytics
 import TwitterKit
+import Firebase
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
     var window: UIWindow?
     var menuViewController: SDSlideMenuViewController!
-    private var analytics: FirebaseScalaDays!
+    private var analytics: ScalaDaysAnalytics!
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         setupThirdParties(application: application, launchOptions: launchOptions)
@@ -61,140 +42,28 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         UINavigationBar.appearance().backIndicatorTransitionMaskImage = UIImage(named: "navigation_bar_icon_arrow")
         SVProgressHUD.setBackgroundColor(UIColor.clear)
     }
-
-    // MARK: life cycle
-    func applicationDidEnterBackground(_ application: UIApplication) {
-        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-        Localytics.dismissCurrentInAppMessage()
-        Localytics.closeSession()
-        Localytics.upload()
-    }
-
-    func applicationWillEnterForeground(_ application: UIApplication) {
-        // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
-        Localytics.openSession()
-        Localytics.upload()
-    }
-
-    func applicationDidBecomeActive(_ application: UIApplication) {
-        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-        Localytics.openSession()
-        Localytics.upload()
-    }
-
-    func applicationWillTerminate(_ application: UIApplication) {
-        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
-        Localytics.dismissCurrentInAppMessage()
-        Localytics.closeSession()
-        Localytics.upload()
-    }
-
-    // MARK: deep link
-    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-        Localytics.handleTestModeURL(url)
-    }
 }
 
-// MARK: Localytics - Push Notifications
-fileprivate let DEBUG_PUSH_NOTIFICATIONS = false
-
+// MARK: Configure 3rd-party libraries
 extension AppDelegate {
     
-    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        Localytics.setPushToken(deviceToken)
-        if DEBUG_PUSH_NOTIFICATIONS {
-            print("@@@@@@@@@@@ TOKEN: \(deviceToken.hexString)")
-        }
-    }
-
-    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
-        print("Registration for Remote Notifications failed with error: \(error)")
-    }
-
-    func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
-        if let jsonReload = userInfo["jsonReload"] as? String, jsonReload.lowercased() == "true" {
-            DataManager.sharedInstance.lastConnectionAttemptDate = nil
-            menuViewController.askControllersToReload()
-        }
-        
-        menuViewController.showNotifications(receivedNotifications: true)
-        Localytics.handleNotificationReceived(userInfo)
-        completionHandler(.noData)
-    }
-    
-    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-        Localytics.didReceiveNotificationResponse(userInfo: response.notification.request.content.userInfo)
-        completionHandler()
-    }
-}
-
-// MARK: Third parties
-extension AppDelegate {
-    private static var externalKeys = AppDelegate.loadExternalKeys()
-
-    private func setupThirdParties(application: UIApplication, launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
-        localyticsPushNotifications(application: application, launchOptions: launchOptions)
-        localytics(application: application, launchOptions: launchOptions)
+    func setupThirdParties(application: UIApplication, launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
         firebase(application: application)
         twitter(application: application)
     }
 
-    private func localyticsPushNotifications(application: UIApplication, launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
-        let options: UNAuthorizationOptions = [.alert, .badge, .sound]
-        UNUserNotificationCenter.current().requestAuthorization(options: options) { (granted, error) in
-            Localytics.didRequestUserNotificationAuthorization(withOptions: options.rawValue, granted: granted)
-        }
-        
-        application.registerForRemoteNotifications()
-    }
-
-    private func localytics(application: UIApplication, launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
-        guard let localyticsKey = AppDelegate.externalKeys.localyticsKey else { return }
-
-        Localytics.autoIntegrate(localyticsKey, withLocalyticsOptions:[
-            LOCALYTICS_WIFI_UPLOAD_INTERVAL_SECONDS: 5,
-            LOCALYTICS_GREAT_NETWORK_UPLOAD_INTERVAL_SECONDS: 10,
-            LOCALYTICS_DECENT_NETWORK_UPLOAD_INTERVAL_SECONDS: 30,
-            LOCALYTICS_BAD_NETWORK_UPLOAD_INTERVAL_SECONDS: 90
-            ], launchOptions: launchOptions)
-
-        Localytics.setLoggingEnabled(DEBUG_PUSH_NOTIFICATIONS)
-
-        if application.applicationState != .background {
-            Localytics.openSession()
-        }
-    }
-
     private func firebase(application: UIApplication) {
-        self.analytics = FirebaseScalaDays()
+        FirebaseApp.configure()
+        analytics = ScalaDaysAnalytics()
+        initializeNotifications(application: application)
     }
 
     private func twitter(application: UIApplication) {
-        guard let twitterConsumerKey = AppDelegate.externalKeys.twitterConsumerKey,
-              let twitterConsumerSecret = AppDelegate.externalKeys.twitterConsumerSecret else { return }
+        guard let path = Bundle.main.path(forResource: kExternalKeysPlistFilename, ofType: "plist"),
+              let keysDict = NSDictionary(contentsOfFile: path),
+              let twitterConsumerKey = keysDict[kExternalKeysDKTwitterConsumerKey] as? String,
+              let twitterConsumerSecret = keysDict[kExternalKeysDKTwitterConsumerSecret] as? String else { return }
 
         TWTRTwitter.sharedInstance().start(withConsumerKey: twitterConsumerKey, consumerSecret: twitterConsumerSecret)
-    }
-}
-
-// MARK: helpers
-// <configuration>
-extension AppDelegate {
-    class func loadExternalKeys() -> (localyticsKey: String?, twitterConsumerKey: String?, twitterConsumerSecret: String?) {
-        guard let path = Bundle.main.path(forResource: kExternalKeysPlistFilename, ofType: "plist"),
-              let keysDict = NSDictionary(contentsOfFile: path) else { return (nil, nil, nil) }
-
-        return (keysDict[kExternalKeysDKLocalytics] as? String,
-                keysDict[kExternalKeysDKTwitterConsumerKey] as? String,
-                keysDict[kExternalKeysDKTwitterConsumerSecret] as? String)
-    }
-}
-
-// <notifications>
-private extension Data {
-    var hexString: String {
-        let hexString = map { String(format: "%02.2hhx", $0) }.joined()
-        return hexString
     }
 }

--- a/ScalaDays/Helpers/Analytics/FirebaseScalaDays.swift
+++ b/ScalaDays/Helpers/Analytics/FirebaseScalaDays.swift
@@ -1,11 +1,7 @@
 import Foundation
 import Firebase
 
-struct FirebaseScalaDays: Analytics {
-    
-    init() {
-        FirebaseApp.configure()
-    }
+struct ScalaDaysAnalytics: Analytics {
     
     func logScreenName(_ screen: AnalyticEvent.ScreenName, class screenClass: UIViewController.Type) {
         Firebase.Analytics.setScreenName("\(screen)", screenClass: String(describing: screenClass))

--- a/ScalaDays/Helpers/SDConstants.swift
+++ b/ScalaDays/Helpers/SDConstants.swift
@@ -18,7 +18,6 @@ import Foundation
 import UIKit
 
 let kExternalKeysPlistFilename = "SDExternalKeys"
-let kExternalKeysDKLocalytics = "Localytics"
 let kExternalKeysDKTwitterConsumerKey = "TwitterConsumerKey"
 let kExternalKeysDKTwitterConsumerSecret = "TwitterConsumerSecret"
 

--- a/ScalaDays/Service/FirebaseNotifications.swift
+++ b/ScalaDays/Service/FirebaseNotifications.swift
@@ -9,6 +9,7 @@ class FirebaseSubscriber: SubscriberNotification {
     func subscribe(conferences: Conferences) {
         conferences.conferences.map(\.info.id).forEach { conferenceId in
             Messaging.messaging().subscribe(toTopic: "\(conferenceId)_\(environment)_ios".lowercased())
+            Messaging.messaging().subscribe(toTopic: "\(environment)_ios".lowercased())
         }
     }
     

--- a/ScalaDays/Service/FirebaseNotifications.swift
+++ b/ScalaDays/Service/FirebaseNotifications.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Firebase
+
+protocol SubscriberNotification {
+    func subscribe(conferences: Conferences)
+}
+
+class FirebaseSubscriber: SubscriberNotification {
+    func subscribe(conferences: Conferences) {
+        conferences.conferences.map(\.info.id).forEach { conferenceId in
+            Messaging.messaging().subscribe(toTopic: "\(conferenceId)_\(environment)_ios".lowercased())
+        }
+    }
+    
+    private var environment: String {
+        #if DEBUG
+        return "debug"
+        #else
+        return "release"
+        #endif
+    }
+}


### PR DESCRIPTION
## Issues
- Closes: #95 

## Description
Because Localytics is pretty outdated with Firebase Console Messenger and GCM is deprecated. Registering the Firebase token for Localytics to receive custom push notifications is at best, inconsistent and wonky so, we will be pulling out the Localytics implementation in favor of using just FCM.

## Implementation details

To determinate each audience, and let us send push notifications between platforms (android, iOS), environments (development, production) and conferences, we will use **topic subscriptions** following the next formula:

< conferenceId > _ < environment > _ < platform >

where
< conferenceId >: is the conference, you can get this information from Conference.info.id
< environment > : debug | release
< platform >: ios | android
